### PR TITLE
Fixed uart send_str to work with Alif Ensemble DFP v2.2.0

### DIFF
--- a/logging/uart_tracelib.c
+++ b/logging/uart_tracelib.c
@@ -209,7 +209,7 @@ int send_str(const char* str, uint32_t len)
             return ret;
         }
 
-        while (USARTdrv->GetTxCount() != len) __WFE();
+        while (USARTdrv->GetTxCount() < len || USARTdrv->GetStatus().tx_busy) __WFE();
     }
     return ret;
 }


### PR DESCRIPTION
This commit caused uart TX to fail with uart tracelib when non-blocking mode is used: https://github.com/alifsemi/alif_ensemble-cmsis-dfp/commit/6973852d528b95e7c329a501faea90f06c0b53b6

Without the fix only one line is printed to uart, then nothing shows in uart.

Looks like USARTdrv->Send(str, len); will return a lot with -2 ( ARM_DRIVER_ERROR_BUSY ) which causes TX to fail.
Reason for why nothing comes to uart after one successful line is a bit unclear. TX line will be freed after next irq to uart tx and after that next send str should succeed. If situation is debugged, it does not occur.

Tested the fix to be working also with old USART driver.